### PR TITLE
Upgraded to use the latest connector version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.logback>1.3.3</version.logback>
     <version.jackson>2.13.4</version.jackson>
-    <version.cdcsdk>1.0.0.RC1</version.cdcsdk>
+    <version.cdcsdk>1.0.0.RC7</version.cdcsdk>
 
     <!-- Deploy -->
     <version.s3.wagon>0.1.3</version.s3.wagon>

--- a/src/test/java/com/yugabyte/cdcsdk/testing/util/CdcsdkContainer.java
+++ b/src/test/java/com/yugabyte/cdcsdk/testing/util/CdcsdkContainer.java
@@ -8,7 +8,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class CdcsdkContainer {
-    private final String bootstrapLogLineRegex = "Checkpoint for tablet";
+    private final String bootstrapLogLineRegex = "Checkpoint from GetTabletListToPollForCDC for tablet";
 
     private final String cdcsdkSourceConnectorClass = "io.debezium.connector.yugabytedb.YugabyteDBConnector";
 

--- a/src/test/java/com/yugabyte/cdcsdk/testing/util/TestImages.java
+++ b/src/test/java/com/yugabyte/cdcsdk/testing/util/TestImages.java
@@ -24,7 +24,7 @@ public class TestImages {
 
     // This Kafka Connect image contains the required drivers and connectors
     // i.e. Postgres JDBC driver, MySql JDBC driver, JDBCSinkConnector
-    public static final String KAFKA_CONNECT_DEFAULT = "quay.io/yugabyte/debezium-connector:1.9.5.y.33";
+    public static final String KAFKA_CONNECT_DEFAULT = "quay.io/yugabyte/debezium-connector:1.9.5.y.33.SNAPSHOT";
 
     public static String getKafkaConnectTestImage() {
         String KAFKA_CONNECT_IMAGE = System.getenv("KAFKA_CONNECT_IMAGE");

--- a/src/test/java/com/yugabyte/cdcsdk/testing/util/TestImages.java
+++ b/src/test/java/com/yugabyte/cdcsdk/testing/util/TestImages.java
@@ -24,7 +24,7 @@ public class TestImages {
 
     // This Kafka Connect image contains the required drivers and connectors
     // i.e. Postgres JDBC driver, MySql JDBC driver, JDBCSinkConnector
-    public static final String KAFKA_CONNECT_DEFAULT = "quay.io/yugabyte/debezium-connector:1.9.5.y.11";
+    public static final String KAFKA_CONNECT_DEFAULT = "quay.io/yugabyte/debezium-connector:1.9.5.y.33";
 
     public static String getKafkaConnectTestImage() {
         String KAFKA_CONNECT_IMAGE = System.getenv("KAFKA_CONNECT_IMAGE");


### PR DESCRIPTION
## Problem
The cdcsdk server test container used to wait till it sees the log line `Checkpoint for tablet <tablet-id>` . However, this log line was modified to `Checkpoint from GetTabletListToPollForCDC for tablet <tablet-id>`. As a result all the tests were failing at container startup.

## Solution
The regex for bootstrap log line has been appropriately updated.